### PR TITLE
AETHER-2861 - Fix for /api/v1/servies POST Query failures + Disabling 

### DIFF
--- a/injectproxy/routes.go
+++ b/injectproxy/routes.go
@@ -229,19 +229,17 @@ func (r *routes) enforceLabel(h http.HandlerFunc) http.Handler {
 			// for now it's not required
 			log.Print("Not an admin getting label for the user group")
 			result := r.defaultGroup  //setting default group
-			if len(groups) > 1 {
-		                grps := []string { }
-			        for i := 0 ; i  < len(groups) ; i++ {
-				     log.Printf(" groups  %s ", groups[i])
-				    // check if it starts with lower case char skip others
-				     if unicode.IsLower([]rune(groups[i])[0]) { 
-				         grps = append(grps,groups[i])
-				     }
-			        }
-				if len(grps) > 0 {
-		                     result = strings.Join(grps, "|")
-			        }
-                       }
+		        grps := []string { }
+			for i := 0 ; i  < len(groups) ; i++ {
+			     log.Printf(" groups  %s ", groups[i])
+			    // check if it starts with lower case char skip others
+			     if unicode.IsLower([]rune(groups[i])[0]) { 
+			         grps = append(grps,groups[i])
+			     }
+			}
+		        if len(grps) > 0 {
+		           result = strings.Join(grps, "|")
+                        }
 			log.Printf("setting label config %s = %s ", r.label,result)
 			req = req.WithContext(withLabelValue(req.Context(), result))
 		} else {
@@ -261,7 +259,6 @@ func (r *routes) enforceLabel(h http.HandlerFunc) http.Handler {
 			q.Del(r.label)
 		}
 		req.URL.RawQuery = q.Encode()
-                log.Printf("Debug request before %v ",req)
 		// Remove the proxy label from the PostForm.
 		if req.Method == http.MethodPost {
 			if err := req.ParseForm(); err != nil {
@@ -277,9 +274,7 @@ func (r *routes) enforceLabel(h http.HandlerFunc) http.Handler {
 				req.ContentLength = int64(len(newBody))
 			}
 		}
-                log.Printf("Debug request after %v ",req)
          	h.ServeHTTP(w, req)
-		//r.handler.ServeHTTP(w, req)
 	})
 }
 
@@ -465,7 +460,6 @@ func enforceQueryValues(e *Enforcer, v url.Values) (values string, noQuery bool,
 // This works for non-query Prometheus APIs like: /api/v1/series, /api/v1/label/<name>/values, /api/v1/labels and /federate support multiple matchers.
 // See e.g https://prometheus.io/docs/prometheus/latest/querying/api/#querying-metadata
 func (r *routes) matcher(w http.ResponseWriter, req *http.Request) {
-	log.Printf("matcher++")
 	matcher := &labels.Matcher{
 		Name:  r.label,
 		Type:  labels.MatchEqual,
@@ -494,7 +488,6 @@ func (r *routes) matcher(w http.ResponseWriter, req *http.Request) {
 }
 
 func injectMatcher(q url.Values, matcher *labels.Matcher) error {
-	log.Printf("injectMatcher++")
 	matchers := q[matchersParam]
 	if len(matchers) == 0 {
 		q.Set(matchersParam, matchersToString(matcher))


### PR DESCRIPTION
--  call to get label config was causing channel block as it's not requirement at this time disabling that added TODO to reintroduce that later
--  enabled support for /api/v1/servies POST queries

-Not to be merge as need some cleaning on log statements